### PR TITLE
Support introspection of http major/minor version

### DIFF
--- a/ext/llhttp/llhttp_ext.c
+++ b/ext/llhttp/llhttp_ext.c
@@ -178,6 +178,22 @@ VALUE rb_llhttp_status_code(VALUE self) {
   return UINT2NUM(parser->status_code);
 }
 
+VALUE rb_llhttp_http_major(VALUE self) {
+  llhttp_t *parser;
+
+  Data_Get_Struct(self, llhttp_t, parser);
+
+  return UINT2NUM(parser->http_major);
+}
+
+VALUE rb_llhttp_http_minor(VALUE self) {
+  llhttp_t *parser;
+
+  Data_Get_Struct(self, llhttp_t, parser);
+
+  return UINT2NUM(parser->http_minor);
+}
+
 VALUE rb_llhttp_keep_alive(VALUE self) {
   llhttp_t *parser;
 
@@ -252,6 +268,8 @@ void Init_llhttp_ext(void) {
   rb_define_method(cParser, "content_length", rb_llhttp_content_length, 0);
   rb_define_method(cParser, "method", rb_llhttp_method, 0);
   rb_define_method(cParser, "status_code", rb_llhttp_status_code, 0);
+  rb_define_method(cParser, "http_major", rb_llhttp_http_major, 0);
+  rb_define_method(cParser, "http_minor", rb_llhttp_http_minor, 0);
 
   rb_define_method(cParser, "keep_alive?", rb_llhttp_keep_alive, 0);
 

--- a/lib/llhttp/parser.rb
+++ b/lib/llhttp/parser.rb
@@ -22,6 +22,8 @@ module LLHttp
   #   * `LLHttp::Parser#content_length` returns the content length of the current request.
   #   * `LLHttp::Parser#method` returns the method of the current response.
   #   * `LLHttp::Parser#status_code` returns the status code of the current response.
+  #   * `LLHttp::Parser#http_major` returns the major http version of the current request/response.
+  #   * `LLHttp::Parser#http_minor` returns the minor http version of the current request/response.
   #   * `LLHttp::Parser#keep_alive?` returns `true` if there might be more messages.
   #
   # Finishing

--- a/spec/integration/introspection/http_major_spec.rb
+++ b/spec/integration/introspection/http_major_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../support/context/parsing"
+
+RSpec.describe "introspection: http major" do
+  include_context "parsing"
+
+  shared_examples "examples" do
+    let(:extension) {
+      proc {
+        def on_headers_complete
+          @context.instance_variable_set(:@http_major, @context.instance.http_major)
+        end
+      }
+    }
+
+    it "returns the http major version" do
+      parse
+
+      expect(@http_major).to eq(1)
+    end
+  end
+
+  context "request" do
+    let(:type) {
+      :request
+    }
+
+    include_examples "examples"
+  end
+
+  context "response" do
+    let(:type) {
+      :response
+    }
+
+    include_examples "examples"
+  end
+end

--- a/spec/integration/introspection/http_minor_spec.rb
+++ b/spec/integration/introspection/http_minor_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../support/context/parsing"
+
+RSpec.describe "introspection: http minor" do
+  include_context "parsing"
+
+  shared_examples "examples" do
+    let(:extension) {
+      proc {
+        def on_headers_complete
+          @context.instance_variable_set(:@http_minor, @context.instance.http_minor)
+        end
+      }
+    }
+
+    it "returns the http minor version" do
+      parse
+
+      expect(@http_minor).to eq(1)
+    end
+  end
+
+  context "request" do
+    let(:type) {
+      :request
+    }
+
+    include_examples "examples"
+  end
+
+  context "response" do
+    let(:type) {
+      :response
+    }
+
+    include_examples "examples"
+  end
+end


### PR DESCRIPTION
Hi
This is the minimal patch to support [http.rb](https://github.com/httprb/http).  
Join the ongoing discussion here: https://github.com/httprb/http/pull/639.