### PR TITLE
Build the extension correctly

### DIFF
--- a/.commit/config.yml
+++ b/.commit/config.yml
@@ -50,7 +50,7 @@ ruby:
   gem:
     namespace: "LLHttp"
     extra: |-2
-        spec.files = Dir["CHANGELOG.md", "README.md", "LICENSE", "lib/**/*"]
+        spec.files = Dir["CHANGELOG.md", "README.md", "LICENSE", "lib/**/*", "ext/**/*"]
         spec.require_path = "lib"
 
         spec.extensions = %w[ext/llhttp/extconf.rb]

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require "rake/extensiontask"
 
 Rake::ExtensionTask.new "llhttp_ext" do |ext|
   ext.ext_dir = "ext/llhttp"
-  ext.lib_dir = "lib/llhttp"
 end
 
 task test: :compile do
@@ -16,8 +15,10 @@ end
 
 task :clean do
   [
-    "./lib/llhttp/llhttp_ext.bundle"
+    "./lib/llhttp_ext.bundle"
   ].each do |file|
+    next unless File.exist?(file)
+
     FileUtils.rm(file)
   end
 end

--- a/ext/llhttp/extconf.rb
+++ b/ext/llhttp/extconf.rb
@@ -2,6 +2,5 @@
 
 require "mkmf"
 
-dir_config "llhttp_ext"
-
-create_makefile "llhttp_ext"
+dir_config("llhttp_ext")
+create_makefile("llhttp_ext")

--- a/lib/llhttp/parser.rb
+++ b/lib/llhttp/parser.rb
@@ -43,4 +43,4 @@ module LLHttp
   end
 end
 
-require_relative "llhttp_ext"
+require_relative "../llhttp_ext"

--- a/llhttp.gemspec
+++ b/llhttp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.license = "MIT"
 
-  spec.files = Dir["CHANGELOG.md", "README.md", "LICENSE", "lib/**/*"]
+  spec.files = Dir["CHANGELOG.md", "README.md", "LICENSE", "lib/**/*", "ext/**/*"]
   spec.require_path = "lib"
 
   spec.extensions = %w[ext/llhttp/extconf.rb]


### PR DESCRIPTION
Fixes the gem by actually including the extension code and removing the bundle before building the gem.