### PR TITLE
Return an error status from the appropriate callbacks

### DIFF
--- a/benchmarks/mri/Gemfile
+++ b/benchmarks/mri/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "benchmark-ips"
+gem "llhttp", path: "../../"

--- a/benchmarks/mri/run.rb
+++ b/benchmarks/mri/run.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "../shared"
+
+benchmark

--- a/benchmarks/shared.rb
+++ b/benchmarks/shared.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "llhttp"
+
+def parse(instance)
+  instance << "GET / HTTP/1.1\r\n"
+  instance << "content-length: 18\r\n"
+  instance << "\r\n"
+  instance << "body1\n"
+  instance << "body2\n"
+  instance << "body3\n"
+  instance << "\r\n"
+end
+
+def benchmark
+  delegate = LLHttp::Delegate.new
+  instance = LLHttp::Parser.new(delegate, type: :request)
+
+  Benchmark.ips do |x|
+    x.report do
+      parse(instance)
+      instance.finish
+    end
+  end
+end

--- a/lib/llhttp/delegate.rb
+++ b/lib/llhttp/delegate.rb
@@ -61,5 +61,37 @@ module LLHttp
     #
     def on_chunk_complete
     end
+
+    private def internal_on_message_begin
+      on_message_begin
+
+      0
+    rescue
+      -1
+    end
+
+    private def internal_on_headers_complete
+      on_headers_complete
+
+      0
+    rescue
+      -1
+    end
+
+    private def internal_on_message_complete
+      on_message_complete
+
+      0
+    rescue
+      -1
+    end
+
+    private def internal_on_chunk_header
+      on_chunk_header
+
+      0
+    rescue
+      -1
+    end
   end
 end

--- a/spec/integration/parser/request_parsing/callback_errors_spec.rb
+++ b/spec/integration/parser/request_parsing/callback_errors_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "llhttp"
+
+RSpec.describe "request parsing callback errors" do
+  let(:instance) {
+    LLHttp::Parser.new(delegate, type: :request)
+  }
+
+  let(:delegate) {
+    local = self
+
+    klass = Class.new(LLHttp::Delegate) {
+      attr_reader :calls
+
+      def initialize
+        @calls = []
+      end
+
+      class_eval(&local.extension)
+    }
+
+    klass.new
+  }
+
+  let(:extension) {
+    proc {}
+  }
+
+  def parse
+    instance << "GET / HTTP/1.1\r\n"
+    instance << "content-length: 18\r\n"
+    instance << "\r\n"
+    instance << "body1\n"
+    instance << "body2\n"
+    instance << "body3\n"
+    instance << "\r\n"
+  end
+
+  describe "on_message_begin" do
+    let(:extension) {
+      proc {
+        def on_message_begin(*args)
+          fail
+        end
+      }
+    }
+
+    it "raises expectedly" do
+      expect {
+        parse
+      }.to raise_error(LLHttp::Error, "Error Parsing data: HPE_CB_MESSAGE_BEGIN `on_message_begin` callback error")
+    end
+  end
+
+  describe "on_headers_complete" do
+    let(:extension) {
+      proc {
+        def on_headers_complete(*args)
+          fail
+        end
+      }
+    }
+
+    it "raises expectedly" do
+      expect {
+        parse
+      }.to raise_error(LLHttp::Error, "Error Parsing data: HPE_CB_HEADERS_COMPLETE User callback error")
+    end
+  end
+
+  describe "on_message_complete" do
+    let(:extension) {
+      proc {
+        def on_message_complete(*args)
+          fail
+        end
+      }
+    }
+
+    it "raises expectedly" do
+      expect {
+        parse
+      }.to raise_error(LLHttp::Error, "Error Parsing data: HPE_CB_MESSAGE_COMPLETE `on_message_complete` callback error")
+    end
+  end
+
+  describe "on_chunk_header" do
+    let(:extension) {
+      proc {
+        def on_chunk_header(*args)
+          fail
+        end
+      }
+    }
+
+    it "raises expectedly"
+  end
+end


### PR DESCRIPTION
Wraps `on_message_begin`, `on_headers_complete`, `on_message_complete`, and `on_chunk_header` to correctly return a `-1` error status. This PR also includes a performance improvement by avoiding calls to `rb_intern` during parsing.