### PR TITLE
Support new *_complete callbacks

### DIFF
--- a/ext/llhttp/llhttp_ext.c
+++ b/ext/llhttp/llhttp_ext.c
@@ -20,6 +20,10 @@ static ID rb_llhttp_callback_on_body;
 static ID rb_llhttp_callback_on_message_complete;
 static ID rb_llhttp_callback_on_chunk_header;
 static ID rb_llhttp_callback_on_chunk_complete;
+static ID rb_llhttp_callback_on_url_complete;
+static ID rb_llhttp_callback_on_status_complete;
+static ID rb_llhttp_callback_on_header_field_complete;
+static ID rb_llhttp_callback_on_header_value_complete;
 
 static void rb_llhttp_free(llhttp_t *parser) {
   if (parser) {
@@ -94,6 +98,30 @@ int rb_llhttp_on_body(llhttp_t *parser, char *data, size_t length) {
 
 int rb_llhttp_on_chunk_complete(llhttp_t *parser) {
   rb_llhttp_callback_call((VALUE)parser->data, rb_llhttp_callback_on_chunk_complete);
+
+  return 0;
+}
+
+int rb_llhttp_on_url_complete(llhttp_t *parser) {
+  rb_llhttp_callback_call((VALUE)parser->data, rb_llhttp_callback_on_url_complete);
+
+  return 0;
+}
+
+int rb_llhttp_on_status_complete(llhttp_t *parser) {
+  rb_llhttp_callback_call((VALUE)parser->data, rb_llhttp_callback_on_status_complete);
+
+  return 0;
+}
+
+int rb_llhttp_on_header_field_complete(llhttp_t *parser) {
+  rb_llhttp_callback_call((VALUE)parser->data, rb_llhttp_callback_on_header_field_complete);
+
+  return 0;
+}
+
+int rb_llhttp_on_header_value_complete(llhttp_t *parser) {
+  rb_llhttp_callback_call((VALUE)parser->data, rb_llhttp_callback_on_header_value_complete);
 
   return 0;
 }
@@ -173,11 +201,17 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
   settings->on_chunk_header = (llhttp_cb)rb_llhttp_on_chunk_header;
 
   settings->on_url = (llhttp_data_cb)rb_llhttp_on_url;
-  settings->on_status = (llhttp_data_cb)rb_llhttp_on_status;
+  settings->on_status_complete = (llhttp_cb)rb_llhttp_on_status_complete;
   settings->on_header_field = (llhttp_data_cb)rb_llhttp_on_header_field;
   settings->on_header_value = (llhttp_data_cb)rb_llhttp_on_header_value;
   settings->on_body = (llhttp_data_cb)rb_llhttp_on_body;
+
   settings->on_chunk_complete = (llhttp_cb)rb_llhttp_on_chunk_complete;
+
+  settings->on_status = (llhttp_data_cb)rb_llhttp_on_status;
+  settings->on_url_complete = (llhttp_cb)rb_llhttp_on_url_complete;
+  settings->on_header_field_complete = (llhttp_cb)rb_llhttp_on_header_field_complete;
+  settings->on_header_value_complete = (llhttp_cb)rb_llhttp_on_header_value_complete;
 
   llhttp_init(parser, FIX2INT(type), settings);
 
@@ -191,7 +225,13 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
   rb_llhttp_callback_on_header_field = rb_intern("on_header_field");
   rb_llhttp_callback_on_header_value = rb_intern("on_header_value");
   rb_llhttp_callback_on_body = rb_intern("on_body");
+
   rb_llhttp_callback_on_chunk_complete = rb_intern("on_chunk_complete");
+
+  rb_llhttp_callback_on_url_complete = rb_intern("on_url_complete");
+  rb_llhttp_callback_on_status_complete = rb_intern("on_status_complete");
+  rb_llhttp_callback_on_header_field_complete = rb_intern("on_header_field_complete");
+  rb_llhttp_callback_on_header_value_complete = rb_intern("on_header_value_complete");
 
   parser->data = (void*)rb_iv_get(self, "@delegate");
 

--- a/lib/llhttp/delegate.rb
+++ b/lib/llhttp/delegate.rb
@@ -62,6 +62,26 @@ module LLHttp
     def on_chunk_complete
     end
 
+    # [public]
+    #
+    def on_url_complete
+    end
+
+    # [public]
+    #
+    def on_status_complete
+    end
+
+    # [public]
+    #
+    def on_header_field_complete
+    end
+
+    # [public]
+    #
+    def on_header_value_complete
+    end
+
     private def internal_on_message_begin
       on_message_begin
 

--- a/spec/integration/callbacks/header_field_complete_spec.rb
+++ b/spec/integration/callbacks/header_field_complete_spec.rb
@@ -2,14 +2,14 @@
 
 require_relative "../support/context/parsing"
 
-RSpec.describe "callbacks: header value" do
+RSpec.describe "callbacks: header field complete" do
   include_context "parsing"
 
   shared_examples "examples" do
     let(:extension) {
       proc {
-        def on_header_value(*args)
-          @calls << [:on_header_value, args]
+        def on_header_field_complete(*args)
+          @calls << [:on_header_field_complete, args]
         end
       }
     }
@@ -18,8 +18,7 @@ RSpec.describe "callbacks: header value" do
       parse
 
       expect(delegate.calls).to eq([
-        [:on_header_value, ["18"]],
-        [:on_header_value, ["text/plain"]]
+        [:on_header_field_complete, []]
       ])
     end
   end

--- a/spec/integration/callbacks/header_field_spec.rb
+++ b/spec/integration/callbacks/header_field_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe "callbacks: header field" do
       parse
 
       expect(delegate.calls).to eq([
-        [:on_header_field, ["content-length"]]
+        [:on_header_field, ["content-length"]],
+        [:on_header_field, ["content-type"]]
       ])
     end
   end

--- a/spec/integration/callbacks/header_value_complete_spec.rb
+++ b/spec/integration/callbacks/header_value_complete_spec.rb
@@ -2,14 +2,14 @@
 
 require_relative "../support/context/parsing"
 
-RSpec.describe "callbacks: header value" do
+RSpec.describe "callbacks: header value complete" do
   include_context "parsing"
 
   shared_examples "examples" do
     let(:extension) {
       proc {
-        def on_header_value(*args)
-          @calls << [:on_header_value, args]
+        def on_header_value_complete(*args)
+          @calls << [:on_header_value_complete, args]
         end
       }
     }
@@ -18,8 +18,8 @@ RSpec.describe "callbacks: header value" do
       parse
 
       expect(delegate.calls).to eq([
-        [:on_header_value, ["18"]],
-        [:on_header_value, ["text/plain"]]
+        [:on_header_value_complete, []],
+        [:on_header_value_complete, []]
       ])
     end
   end

--- a/spec/integration/callbacks/status_complete_spec.rb
+++ b/spec/integration/callbacks/status_complete_spec.rb
@@ -2,14 +2,14 @@
 
 require_relative "../support/context/parsing"
 
-RSpec.describe "callbacks: header value" do
+RSpec.describe "callbacks: status complete" do
   include_context "parsing"
 
   shared_examples "examples" do
     let(:extension) {
       proc {
-        def on_header_value(*args)
-          @calls << [:on_header_value, args]
+        def on_status_complete(*args)
+          @calls << [:on_status_complete, args]
         end
       }
     }
@@ -18,18 +18,9 @@ RSpec.describe "callbacks: header value" do
       parse
 
       expect(delegate.calls).to eq([
-        [:on_header_value, ["18"]],
-        [:on_header_value, ["text/plain"]]
+        [:on_status_complete, []]
       ])
     end
-  end
-
-  context "request" do
-    let(:type) {
-      :request
-    }
-
-    include_examples "examples"
   end
 
   context "response" do

--- a/spec/integration/callbacks/url_complete_spec.rb
+++ b/spec/integration/callbacks/url_complete_spec.rb
@@ -2,14 +2,14 @@
 
 require_relative "../support/context/parsing"
 
-RSpec.describe "callbacks: header value" do
+RSpec.describe "callbacks: url complete" do
   include_context "parsing"
 
   shared_examples "examples" do
     let(:extension) {
       proc {
-        def on_header_value(*args)
-          @calls << [:on_header_value, args]
+        def on_url_complete(*args)
+          @calls << [:on_url_complete, args]
         end
       }
     }
@@ -18,8 +18,7 @@ RSpec.describe "callbacks: header value" do
       parse
 
       expect(delegate.calls).to eq([
-        [:on_header_value, ["18"]],
-        [:on_header_value, ["text/plain"]]
+        [:on_url_complete, []]
       ])
     end
   end
@@ -27,14 +26,6 @@ RSpec.describe "callbacks: header value" do
   context "request" do
     let(:type) {
       :request
-    }
-
-    include_examples "examples"
-  end
-
-  context "response" do
-    let(:type) {
-      :response
     }
 
     include_examples "examples"

--- a/spec/integration/reusing_spec.rb
+++ b/spec/integration/reusing_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe "reusing a parser instance" do
       end
 
       expect(delegate.calls.count(:on_message_begin)).to eq(10_000)
-      expect(delegate.calls.count(:on_header_field)).to eq(10_000)
-      expect(delegate.calls.count(:on_header_value)).to eq(10_000)
+      expect(delegate.calls.count(:on_header_field)).to eq(20_000)
+      expect(delegate.calls.count(:on_header_value)).to eq(20_000)
       expect(delegate.calls.count(:on_headers_complete)).to eq(10_000)
       expect(delegate.calls.count(:on_body)).to eq(30_000)
       expect(delegate.calls.count(:on_message_complete)).to eq(10_000)

--- a/spec/integration/support/context/parsing.rb
+++ b/spec/integration/support/context/parsing.rb
@@ -84,6 +84,7 @@ RSpec.shared_context "parsing" do
       request: [
         "GET / HTTP/1.1\r\n",
         "content-length: 18\r\n",
+        "content-type: text/plain\r\n",
         "\r\n",
         "body1\n",
         "body2\n",
@@ -94,6 +95,7 @@ RSpec.shared_context "parsing" do
       response: [
         "HTTP/1.1 200 OK\r\n",
         "content-length: 18\r\n",
+        "content-type: text/plain\r\n",
         "\r\n",
         "body1\n",
         "body2\n",


### PR DESCRIPTION
Adds support for the following callbacks:

* `on_url_complete`
* `on_status_complete`
* `on_header_field_complete`
* `on_header_value_complete`