### PR TITLE
Only setup callbacks if they are defined on the delegate

### DIFF
--- a/ext/llhttp/llhttp_ext.c
+++ b/ext/llhttp/llhttp_ext.c
@@ -211,23 +211,63 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
 
   llhttp_settings_t *settings = parser->settings;
 
-  settings->on_message_begin = (llhttp_cb)rb_llhttp_on_message_begin;
-  settings->on_headers_complete = (llhttp_cb)rb_llhttp_on_headers_complete;
-  settings->on_message_complete = (llhttp_cb)rb_llhttp_on_message_complete;
-  settings->on_chunk_header = (llhttp_cb)rb_llhttp_on_chunk_header;
+  VALUE delegate = rb_iv_get(self, "@delegate");
 
-  settings->on_url = (llhttp_data_cb)rb_llhttp_on_url;
-  settings->on_status_complete = (llhttp_cb)rb_llhttp_on_status_complete;
-  settings->on_header_field = (llhttp_data_cb)rb_llhttp_on_header_field;
-  settings->on_header_value = (llhttp_data_cb)rb_llhttp_on_header_value;
-  settings->on_body = (llhttp_data_cb)rb_llhttp_on_body;
+  if (rb_respond_to(delegate, rb_intern("on_message_begin"))) {
+    settings->on_message_begin = (llhttp_cb)rb_llhttp_on_message_begin;
+  }
 
-  settings->on_chunk_complete = (llhttp_cb)rb_llhttp_on_chunk_complete;
+  if (rb_respond_to(delegate, rb_intern("on_headers_complete"))) {
+    settings->on_headers_complete = (llhttp_cb)rb_llhttp_on_headers_complete;
+  }
 
-  settings->on_status = (llhttp_data_cb)rb_llhttp_on_status;
-  settings->on_url_complete = (llhttp_cb)rb_llhttp_on_url_complete;
-  settings->on_header_field_complete = (llhttp_cb)rb_llhttp_on_header_field_complete;
-  settings->on_header_value_complete = (llhttp_cb)rb_llhttp_on_header_value_complete;
+  if (rb_respond_to(delegate, rb_intern("on_message_complete"))) {
+    settings->on_message_complete = (llhttp_cb)rb_llhttp_on_message_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_chunk_header"))) {
+    settings->on_chunk_header = (llhttp_cb)rb_llhttp_on_chunk_header;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_url"))) {
+    settings->on_url = (llhttp_data_cb)rb_llhttp_on_url;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_status_complete"))) {
+    settings->on_status_complete = (llhttp_cb)rb_llhttp_on_status_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_header_field"))) {
+    settings->on_header_field = (llhttp_data_cb)rb_llhttp_on_header_field;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_header_value"))) {
+    settings->on_header_value = (llhttp_data_cb)rb_llhttp_on_header_value;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_body"))) {
+    settings->on_body = (llhttp_data_cb)rb_llhttp_on_body;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_chunk_complete"))) {
+    settings->on_chunk_complete = (llhttp_cb)rb_llhttp_on_chunk_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_status"))) {
+    settings->on_status = (llhttp_data_cb)rb_llhttp_on_status;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_url_complete"))) {
+    settings->on_url_complete = (llhttp_cb)rb_llhttp_on_url_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_header_field_complete"))) {
+    settings->on_header_field_complete = (llhttp_cb)rb_llhttp_on_header_field_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_intern("on_header_value_complete"))) {
+    settings->on_header_value_complete = (llhttp_cb)rb_llhttp_on_header_value_complete;
+  }
 
   llhttp_init(parser, FIX2INT(type), settings);
 
@@ -249,7 +289,7 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
   rb_llhttp_callback_on_header_field_complete = rb_intern("on_header_field_complete");
   rb_llhttp_callback_on_header_value_complete = rb_intern("on_header_value_complete");
 
-  parser->data = (void*)rb_iv_get(self, "@delegate");
+  parser->data = (void*)delegate;
 
   return Qtrue;
 }

--- a/ext/llhttp/llhttp_ext.c
+++ b/ext/llhttp/llhttp_ext.c
@@ -213,6 +213,21 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
 
   VALUE delegate = rb_iv_get(self, "@delegate");
 
+  rb_llhttp_callback_on_message_begin = rb_intern("internal_on_message_begin");
+  rb_llhttp_callback_on_headers_complete = rb_intern("internal_on_headers_complete");
+  rb_llhttp_callback_on_message_complete = rb_intern("internal_on_message_complete");
+  rb_llhttp_callback_on_chunk_header = rb_intern("internal_on_chunk_header");
+  rb_llhttp_callback_on_url = rb_intern("on_url");
+  rb_llhttp_callback_on_status = rb_intern("on_status");
+  rb_llhttp_callback_on_header_field = rb_intern("on_header_field");
+  rb_llhttp_callback_on_header_value = rb_intern("on_header_value");
+  rb_llhttp_callback_on_body = rb_intern("on_body");
+  rb_llhttp_callback_on_chunk_complete = rb_intern("on_chunk_complete");
+  rb_llhttp_callback_on_url_complete = rb_intern("on_url_complete");
+  rb_llhttp_callback_on_status_complete = rb_intern("on_status_complete");
+  rb_llhttp_callback_on_header_field_complete = rb_intern("on_header_field_complete");
+  rb_llhttp_callback_on_header_value_complete = rb_intern("on_header_value_complete");
+
   if (rb_respond_to(delegate, rb_intern("on_message_begin"))) {
     settings->on_message_begin = (llhttp_cb)rb_llhttp_on_message_begin;
   }
@@ -229,65 +244,47 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
     settings->on_chunk_header = (llhttp_cb)rb_llhttp_on_chunk_header;
   }
 
-  if (rb_respond_to(delegate, rb_intern("on_url"))) {
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_url)) {
     settings->on_url = (llhttp_data_cb)rb_llhttp_on_url;
   }
 
-  if (rb_respond_to(delegate, rb_intern("on_status_complete"))) {
-    settings->on_status_complete = (llhttp_cb)rb_llhttp_on_status_complete;
-  }
-
-  if (rb_respond_to(delegate, rb_intern("on_header_field"))) {
-    settings->on_header_field = (llhttp_data_cb)rb_llhttp_on_header_field;
-  }
-
-  if (rb_respond_to(delegate, rb_intern("on_header_value"))) {
-    settings->on_header_value = (llhttp_data_cb)rb_llhttp_on_header_value;
-  }
-
-  if (rb_respond_to(delegate, rb_intern("on_body"))) {
-    settings->on_body = (llhttp_data_cb)rb_llhttp_on_body;
-  }
-
-  if (rb_respond_to(delegate, rb_intern("on_chunk_complete"))) {
-    settings->on_chunk_complete = (llhttp_cb)rb_llhttp_on_chunk_complete;
-  }
-
-  if (rb_respond_to(delegate, rb_intern("on_status"))) {
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_status)) {
     settings->on_status = (llhttp_data_cb)rb_llhttp_on_status;
   }
 
-  if (rb_respond_to(delegate, rb_intern("on_url_complete"))) {
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_header_field)) {
+    settings->on_header_field = (llhttp_data_cb)rb_llhttp_on_header_field;
+  }
+
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_header_value)) {
+    settings->on_header_value = (llhttp_data_cb)rb_llhttp_on_header_value;
+  }
+
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_body)) {
+    settings->on_body = (llhttp_data_cb)rb_llhttp_on_body;
+  }
+
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_chunk_complete)) {
+    settings->on_chunk_complete = (llhttp_cb)rb_llhttp_on_chunk_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_url_complete)) {
     settings->on_url_complete = (llhttp_cb)rb_llhttp_on_url_complete;
   }
 
-  if (rb_respond_to(delegate, rb_intern("on_header_field_complete"))) {
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_status_complete)) {
+    settings->on_status_complete = (llhttp_cb)rb_llhttp_on_status_complete;
+  }
+
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_header_field_complete)) {
     settings->on_header_field_complete = (llhttp_cb)rb_llhttp_on_header_field_complete;
   }
 
-  if (rb_respond_to(delegate, rb_intern("on_header_value_complete"))) {
+  if (rb_respond_to(delegate, rb_llhttp_callback_on_header_value_complete)) {
     settings->on_header_value_complete = (llhttp_cb)rb_llhttp_on_header_value_complete;
   }
 
   llhttp_init(parser, FIX2INT(type), settings);
-
-  rb_llhttp_callback_on_message_begin = rb_intern("internal_on_message_begin");
-  rb_llhttp_callback_on_headers_complete = rb_intern("internal_on_headers_complete");
-  rb_llhttp_callback_on_message_complete = rb_intern("internal_on_message_complete");
-  rb_llhttp_callback_on_chunk_header = rb_intern("internal_on_chunk_header");
-
-  rb_llhttp_callback_on_url = rb_intern("on_url");
-  rb_llhttp_callback_on_status = rb_intern("on_status");
-  rb_llhttp_callback_on_header_field = rb_intern("on_header_field");
-  rb_llhttp_callback_on_header_value = rb_intern("on_header_value");
-  rb_llhttp_callback_on_body = rb_intern("on_body");
-
-  rb_llhttp_callback_on_chunk_complete = rb_intern("on_chunk_complete");
-
-  rb_llhttp_callback_on_url_complete = rb_intern("on_url_complete");
-  rb_llhttp_callback_on_status_complete = rb_intern("on_status_complete");
-  rb_llhttp_callback_on_header_field_complete = rb_intern("on_header_field_complete");
-  rb_llhttp_callback_on_header_value_complete = rb_intern("on_header_value_complete");
 
   parser->data = (void*)delegate;
 

--- a/lib/llhttp/delegate.rb
+++ b/lib/llhttp/delegate.rb
@@ -8,80 +8,60 @@ module LLHttp
   #       ...
   #     end
   #
-  #     ...
+  #     def on_url(url)
+  #       ...
+  #     end
+  #
+  #     def on_status(status)
+  #       ...
+  #     end
+  #
+  #     def on_header_field(field)
+  #       ...
+  #     end
+  #
+  #     def on_header_value(value)
+  #       ...
+  #     end
+  #
+  #     def on_headers_complete
+  #       ...
+  #     end
+  #
+  #     def on_body(body)
+  #       ...
+  #     end
+  #
+  #     def on_message_complete
+  #       ...
+  #     end
+  #
+  #     def on_chunk_header
+  #       ...
+  #     end
+  #
+  #     def on_chunk_complete
+  #       ...
+  #     end
+  #
+  #     def on_url_complete
+  #       ...
+  #     end
+  #
+  #     def on_status_complete
+  #       ...
+  #     end
+  #
+  #     def on_header_field_complete
+  #       ...
+  #     end
+  #
+  #     def on_header_value_complete
+  #       ...
+  #     end
   #   end
   #
   class Delegate
-    # [public]
-    #
-    def on_message_begin
-    end
-
-    # [public]
-    #
-    def on_url(url)
-    end
-
-    # [public]
-    #
-    def on_status(status)
-    end
-
-    # [public]
-    #
-    def on_header_field(field)
-    end
-
-    # [public]
-    #
-    def on_header_value(value)
-    end
-
-    # [public]
-    #
-    def on_headers_complete
-    end
-
-    # [public]
-    #
-    def on_body(body)
-    end
-
-    # [public]
-    #
-    def on_message_complete
-    end
-
-    # [public]
-    #
-    def on_chunk_header
-    end
-
-    # [public]
-    #
-    def on_chunk_complete
-    end
-
-    # [public]
-    #
-    def on_url_complete
-    end
-
-    # [public]
-    #
-    def on_status_complete
-    end
-
-    # [public]
-    #
-    def on_header_field_complete
-    end
-
-    # [public]
-    #
-    def on_header_value_complete
-    end
-
     private def internal_on_message_begin
       on_message_begin
 


### PR DESCRIPTION
Improves performance by 340% for empty delegates. Real world performance won't be quite as stark, but will likely improve.

```
Warming up --------------------------------------
                        71.634k i/100ms
Calculating -------------------------------------
                        701.657k (± 4.7%) i/s -      3.510M in   5.014145s
```

```
Warming up --------------------------------------
                       243.112k i/100ms
Calculating -------------------------------------
                          2.391M (± 2.8%) i/s -     12.156M in   5.088172s
```