### PR TITLE
Rename Parser#method to Parser#method_name

### DIFF
--- a/ext/llhttp/llhttp_ext.c
+++ b/ext/llhttp/llhttp_ext.c
@@ -162,7 +162,7 @@ VALUE rb_llhttp_content_length(VALUE self) {
   return ULL2NUM(parser->content_length);
 }
 
-VALUE rb_llhttp_method(VALUE self) {
+VALUE rb_llhttp_method_name(VALUE self) {
   llhttp_t *parser;
 
   Data_Get_Struct(self, llhttp_t, parser);
@@ -303,7 +303,7 @@ void Init_llhttp_ext(void) {
   rb_define_method(cParser, "finish", rb_llhttp_finish, 0);
 
   rb_define_method(cParser, "content_length", rb_llhttp_content_length, 0);
-  rb_define_method(cParser, "method", rb_llhttp_method, 0);
+  rb_define_method(cParser, "method_name", rb_llhttp_method_name, 0);
   rb_define_method(cParser, "status_code", rb_llhttp_status_code, 0);
   rb_define_method(cParser, "http_major", rb_llhttp_http_major, 0);
   rb_define_method(cParser, "http_minor", rb_llhttp_http_minor, 0);

--- a/lib/llhttp/parser.rb
+++ b/lib/llhttp/parser.rb
@@ -20,7 +20,7 @@ module LLHttp
   # Introspection
   #
   #   * `LLHttp::Parser#content_length` returns the content length of the current request.
-  #   * `LLHttp::Parser#method` returns the method of the current response.
+  #   * `LLHttp::Parser#method_name` returns the method name of the current response.
   #   * `LLHttp::Parser#status_code` returns the status code of the current response.
   #   * `LLHttp::Parser#http_major` returns the major http version of the current request/response.
   #   * `LLHttp::Parser#http_minor` returns the minor http version of the current request/response.

--- a/spec/integration/introspection/method_name_spec.rb
+++ b/spec/integration/introspection/method_name_spec.rb
@@ -2,14 +2,14 @@
 
 require_relative "../support/context/parsing"
 
-RSpec.describe "introspection: method" do
+RSpec.describe "introspection: method name" do
   include_context "parsing"
 
   shared_examples "examples" do
     let(:extension) {
       proc {
         def on_headers_complete
-          @context.instance_variable_set(:@method, @context.instance.method)
+          @context.instance_variable_set(:@method_name, @context.instance.method_name)
         end
       }
     }
@@ -17,7 +17,7 @@ RSpec.describe "introspection: method" do
     it "returns the content" do
       parse
 
-      expect(@method).to eq("GET")
+      expect(@method_name).to eq("GET")
     end
   end
 


### PR DESCRIPTION
Best to avoid overloading `Object#method` in this case. It's also more consistent with the underlying `llhttp` library.