### PR TITLE
Add back support for Ruby 2.5 in ffi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,38 @@ on:
   push:
 
 jobs:
-  test-ruby:
+  lint:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ruby }}
+
+    strategy:
+      matrix:
+        ruby:
+          - 2.5
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+
+      - name: Install Dependencies
+        shell: bash -l -e -o pipefail {0}
+        run: |
+          rm -f Gemfile.lock
+          bundle install --jobs=3 && bundle update --jobs=3
+
+      - name: Run Linter
+        shell: bash -l -e -o pipefail {0}
+        run: |
+          CI=true bundle exec standardrb
+
+  test-ffi:
     runs-on: ubuntu-latest
 
     name: ${{ matrix.ruby }}
@@ -36,10 +67,46 @@ jobs:
           rm -f Gemfile.lock
           bundle install --jobs=3 && bundle update --jobs=3
 
-      - name: Run Linter
+      - name: Install FFI Dependencies
+        shell: bash -l -e -o pipefail {0}
+        working-directory: ./ffi
+        run: |
+          rm -f Gemfile.lock
+          bundle install --jobs=3 && bundle update --jobs=3
+
+      - name: Run FFI Tests
+        shell: bash -l -e -o pipefail {0}
+        working-directory: ./ffi
+        run: |
+          CI=true bundle exec rake test
+
+  test-mri:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ruby }}
+
+    strategy:
+      matrix:
+        ruby:
+          - 2.6
+          - 2.7
+          - 3.0
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+
+      - name: Install Dependencies
         shell: bash -l -e -o pipefail {0}
         run: |
-          CI=true bundle exec standardrb
+          rm -f Gemfile.lock
+          bundle install --jobs=3 && bundle update --jobs=3
 
       - name: Install MRI Dependencies
         shell: bash -l -e -o pipefail {0}
@@ -51,18 +118,5 @@ jobs:
       - name: Run MRI Tests
         shell: bash -l -e -o pipefail {0}
         working-directory: ./mri
-        run: |
-          CI=true bundle exec rake test
-
-      - name: Install FFI Dependencies
-        shell: bash -l -e -o pipefail {0}
-        working-directory: ./ffi
-        run: |
-          rm -f Gemfile.lock
-          bundle install --jobs=3 && bundle update --jobs=3
-
-      - name: Run FFI Tests
-        shell: bash -l -e -o pipefail {0}
-        working-directory: ./ffi
         run: |
           CI=true bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    name: ${{ matrix.ruby }}
+    name: Lint ${{ matrix.ruby }}
 
     strategy:
       matrix:
@@ -41,7 +41,7 @@ jobs:
   test-ffi:
     runs-on: ubuntu-latest
 
-    name: ${{ matrix.ruby }}
+    name: Test FFI ${{ matrix.ruby }}
 
     strategy:
       matrix:
@@ -83,7 +83,7 @@ jobs:
   test-mri:
     runs-on: ubuntu-latest
 
-    name: ${{ matrix.ruby }}
+    name: Test MRI ${{ matrix.ruby }}
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 2.5
           - 2.6
           - 2.7
           - 3.0

--- a/ffi/.commit/config.yml
+++ b/ffi/.commit/config.yml
@@ -42,6 +42,7 @@ ruby:
   gem:
     path: "llhttp"
     namespace: "LLHttp"
+    version: "2.5.0"
     extra: |-2
         spec.files = Dir["CHANGELOG.md", "README.md", "LICENSE", "lib/**/*", "ext/**/*"]
         spec.require_path = "lib"

--- a/ffi/llhttp-ffi.gemspec
+++ b/ffi/llhttp-ffi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@metabahn.com"
   spec.homepage = "https://github.com/metabahn/llhttp/"
 
-  spec.required_ruby_version = ">= 2.6.7"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.license = "MPL-2.0"
 

--- a/mri/llhttp.gemspec
+++ b/mri/llhttp.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@metabahn.com"
   spec.homepage = "https://github.com/metabahn/llhttp/"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.7"
 
   spec.license = "MPL-2.0"
 

--- a/mri/llhttp.gemspec
+++ b/mri/llhttp.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email = "bryan@metabahn.com"
   spec.homepage = "https://github.com/metabahn/llhttp/"
 
-  spec.required_ruby_version = ">= 2.6.7"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.license = "MPL-2.0"
 


### PR DESCRIPTION
Reverts #18 for `llhttp-ffi` as dependent projects (e.g. http.rb) require Ruby 2.5.