### PR TITLE
Add support for resetting the parser

### DIFF
--- a/ffi/README.md
+++ b/ffi/README.md
@@ -33,5 +33,5 @@ parser << "GET / HTTP/1.1\r\n\r\n"
 
 # Reset the parser for the next request:
 #
-parser.finish
+parser.reset
 ```

--- a/ffi/lib/llhttp.rb
+++ b/ffi/lib/llhttp.rb
@@ -45,4 +45,5 @@ module LLHttp
   attach_function :llhttp_get_error_reason, [:pointer], :string
   attach_function :llhttp_should_keep_alive, [:pointer], :int
   attach_function :llhttp_finish, [:pointer], :int
+  attach_function :llhttp_reset, [:pointer], :void
 end

--- a/ffi/lib/llhttp/parser.rb
+++ b/ffi/lib/llhttp/parser.rb
@@ -117,10 +117,16 @@ module LLHttp
       LLHttp.llhttp_should_keep_alive(@pointer) == 1
     end
 
-    # [public] Get ready to parse the next request.
+    # [public] Tells the parser we are finished.
     #
     def finish
       LLHttp.llhttp_finish(@pointer)
+    end
+
+    # [public] Get ready to parse the next request/response.
+    #
+    def reset
+      LLHttp.llhttp_reset(@pointer)
     end
 
     CALLBACKS.each do |callback|

--- a/mri/README.md
+++ b/mri/README.md
@@ -33,5 +33,5 @@ parser << "GET / HTTP/1.1\r\n\r\n"
 
 # Reset the parser for the next request:
 #
-parser.finish
+parser.reset
 ```

--- a/mri/ext/llhttp/llhttp_ext.c
+++ b/mri/ext/llhttp/llhttp_ext.c
@@ -154,6 +154,18 @@ VALUE rb_llhttp_finish(VALUE self) {
   return Qtrue;
 }
 
+VALUE rb_llhttp_reset(VALUE self) {
+  llhttp_t *parser;
+
+  Data_Get_Struct(self, llhttp_t, parser);
+
+  llhttp_settings_t *settings = parser->settings;
+
+  llhttp_reset(parser);
+
+  return Qtrue;
+}
+
 VALUE rb_llhttp_content_length(VALUE self) {
   llhttp_t *parser;
 
@@ -301,6 +313,7 @@ void Init_llhttp_ext(void) {
   rb_define_method(cParser, "<<", rb_llhttp_parse, 1);
   rb_define_method(cParser, "parse", rb_llhttp_parse, 1);
   rb_define_method(cParser, "finish", rb_llhttp_finish, 0);
+  rb_define_method(cParser, "reset", rb_llhttp_reset, 0);
 
   rb_define_method(cParser, "content_length", rb_llhttp_content_length, 0);
   rb_define_method(cParser, "method_name", rb_llhttp_method_name, 0);

--- a/mri/lib/llhttp/parser.rb
+++ b/mri/lib/llhttp/parser.rb
@@ -30,6 +30,10 @@ module LLHttp
   #
   #   Call `LLHttp::Parser#finish` when processing is complete for the current request or response.
   #
+  # Resetting
+  #
+  #   Call `LLHttp::Parser#reset` to reset the parser for the next request or response.
+  #
   class Parser
     LLHTTP_TYPES = {both: 0, request: 1, response: 2}.freeze
 

--- a/spec/acceptance/support/server.rb
+++ b/spec/acceptance/support/server.rb
@@ -49,7 +49,7 @@ class Server
   ensure
     stream.close
 
-    @parser.finish
+    @parser.reset
   end
 
   private def parse_next(stream)

--- a/spec/integration/no_content_length_spec.rb
+++ b/spec/integration/no_content_length_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "support/context/parsing"
 
-RSpec.describe "reusing a parser instance" do
+RSpec.describe "parsing responses without a content length" do
   include_context "parsing"
 
   shared_examples "examples" do
@@ -42,25 +42,21 @@ RSpec.describe "reusing a parser instance" do
       end
 
       expect(delegate.calls.count(:on_message_begin)).to eq(10_000)
-      expect(delegate.calls.count(:on_header_field)).to eq(20_000)
-      expect(delegate.calls.count(:on_header_value)).to eq(20_000)
+      expect(delegate.calls.count(:on_header_field)).to eq(0)
+      expect(delegate.calls.count(:on_header_value)).to eq(0)
       expect(delegate.calls.count(:on_headers_complete)).to eq(10_000)
-      expect(delegate.calls.count(:on_body)).to eq(30_000)
-      expect(delegate.calls.count(:on_message_complete)).to eq(10_000)
+      expect(delegate.calls.count(:on_body)).to eq(0)
+      expect(delegate.calls.count(:on_message_complete)).to eq(0)
     end
-  end
-
-  context "request" do
-    let(:type) {
-      :request
-    }
-
-    include_examples "examples"
   end
 
   context "response" do
     let(:type) {
       :response
+    }
+
+    let(:fixture) {
+      :response_sans_content_length
     }
 
     include_examples "examples"

--- a/spec/integration/support/context/parsing.rb
+++ b/spec/integration/support/context/parsing.rb
@@ -101,6 +101,10 @@ RSpec.shared_context "parsing" do
         "body2\n",
         "body3\n",
         "\r\n"
+      ],
+
+      response_sans_content_length: [
+        "HTTP/1.1 200 OK\r\n\r\n"
       ]
     }
   }


### PR DESCRIPTION
Per https://github.com/nodejs/llhttp/issues/128, the parser should be reset before handling the next request or response.