### PR TITLE
Do not use require_relative with native extension

### DIFF
--- a/ffi/Gemfile
+++ b/ffi/Gemfile
@@ -12,5 +12,9 @@ end
 group :test do
   gem "async"
   gem "io-endpoint"
+  # io-event 1.9.0 broke the compat with our "fork based test"
+  # See discussion in https://github.com/bryanp/llhttp/pull/34
+  #               and https://github.com/socketry/io-event/issues/36
+  gem "io-event", "~> 1.8.0"
   gem "rspec"
 end

--- a/ffi/lib/llhttp.rb
+++ b/ffi/lib/llhttp.rb
@@ -10,6 +10,7 @@ module LLHttp
   require_relative "llhttp/version"
 
   extend FFI::Library
+
   ffi_lib(FFI::Compiler::Loader.find("llhttp-ext"))
 
   callback :llhttp_data_cb, [:pointer, :size_t], :void

--- a/mri/Gemfile
+++ b/mri/Gemfile
@@ -12,5 +12,9 @@ end
 group :test do
   gem "async"
   gem "io-endpoint"
+  # io-event 1.9.0 broke the compat with our "fork based test"
+  # See discussion in https://github.com/bryanp/llhttp/pull/34
+  #               and https://github.com/socketry/io-event/issues/36
+  gem "io-event", "~> 1.8.0"
   gem "rspec"
 end

--- a/mri/lib/llhttp/parser.rb
+++ b/mri/lib/llhttp/parser.rb
@@ -49,4 +49,4 @@ module LLHttp
   end
 end
 
-require_relative "../llhttp_ext"
+require "llhttp_ext"


### PR DESCRIPTION
Replace `require_relative "../llhttp_ext"` by `require "llhttp_ext"` to load the native extension.
This improves compatibility with Bundler and RubyGems, especially in environments using `bundle install --standalone` or other setups where the extension may not be located relative to the Ruby file.

Using `require` ensures the extension is loaded from the load path, following RubyGems best practices for native extensions.

Fix #33 