### PR TITLE
Declare functions as Ractor-safe

### DIFF
--- a/mri/ext/llhttp/extconf.rb
+++ b/mri/ext/llhttp/extconf.rb
@@ -3,4 +3,8 @@
 require "mkmf"
 
 dir_config("llhttp_ext")
+
+# Check for Ractor support
+have_func("rb_ext_ractor_safe", "ruby.h")
+
 create_makefile("llhttp_ext")

--- a/mri/ext/llhttp/llhttp_ext.c
+++ b/mri/ext/llhttp/llhttp_ext.c
@@ -341,6 +341,10 @@ static VALUE rb_llhttp_init(VALUE self, VALUE type) {
 }
 
 void Init_llhttp_ext(void) {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+  rb_ext_ractor_safe(true);
+#endif
+
   mLLHttp = rb_const_get(rb_cObject, rb_intern("LLHttp"));
   cParser = rb_const_get(mLLHttp, rb_intern("Parser"));
   eError = rb_const_get(mLLHttp, rb_intern("Error"));


### PR DESCRIPTION
As far as I can tell this should be thread-safe in C land, so we should be okay declaring the extension as Ractor-safe.

Note that this doesn't allow sharing of Parser objects between Ractors